### PR TITLE
Fix package manager/build system, add instructions to build the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ Also the non-printable `SOH` character (`\001`) is handled correctly.
 
 Using pipe characters (`|`) as separators is also supported.
 
+How to build
+============
+
+In order to build this project, you need to have 2 tools installed on your computer: yarn (package manager), and gulp (build system). Please find below the link to their respective documentation:
+* [Yarn installation documentation](https://yarnpkg.com/lang/en/docs/install/)
+* [Gulp Getting Started wiki page](https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md)
+
+To download the dependancies, run on the repository's folder:
+
+> yarn install
+
+Then to build the project, just type:
+
+> gulp
+
+The files will be copied on the 'dist' directory.
+
 License
 =======
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,6 @@
 var gulp = require('gulp');
 
 // Include plugins dependencies
-var concat = require('gulp-concat');
 var rename = require('gulp-rename');
 var uglify = require('gulp-uglify');
 
@@ -12,14 +11,22 @@ gulp.task('app', function() {
         .pipe(gulp.dest('dist/scripts/app'))
 });
 
-// Copy & minify external js files
+// Copy external js files which are already minified
 gulp.task('lib', function() {
 	return gulp.src(
 		[
-			'node_modules/jquery/dist/jquery.js',
-			'node_modules/lodash/dist/lodash.js',
+			'node_modules/jquery/dist/jquery.min.js',
+			'node_modules/lodash/dist/lodash.min.js',
+			'node_modules/handlebars/dist/handlebars.min.js'
+		])
+        .pipe(gulp.dest('dist/scripts/lib'))
+});
+
+// Copy & minify external js files which are not already minified
+gulp.task('lib-min', function() {
+	return gulp.src(
+		[
 			'node_modules/requirejs/require.js',
-			'node_modules/handlebars/dist/handlebars.js'
 		])
         .pipe(uglify())
 		.pipe(rename(function (path) {
@@ -34,7 +41,7 @@ gulp.task('styles', function() {
         .pipe(gulp.dest('dist/styles'))
 });
 
-// Copy incdex.html file
+// Copy index.html file
 gulp.task('index', function() {
 	return gulp.src('src/index.html')
 		.pipe(gulp.dest('dist'));
@@ -46,4 +53,4 @@ gulp.task('img', function() {
         .pipe(gulp.dest('dist/img'))
 });
 
-gulp.task('default', ['app', 'lib', 'styles', 'index', 'img']);
+gulp.task('default', ['app', 'lib', 'lib-min', 'styles', 'index', 'img']);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "gulp": "^3.9.1",
-    "gulp-concat": "^2.6.1",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^2.1.2"
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "gulp-rename": "^1.2.2",
-    "gulp-uglify": "^2.1.2",
+    "gulp-uglify": "^2.1.2"
   }
 }


### PR DESCRIPTION
Hi Drew,

Sorry for the delay, I create this pull request to fix the issues which have been found on my previous pull request :
* Add instructions to build the project on the read me file
* Remove typos (the comma in package.json, and the comment on gulpfile.js)
* Remove gulp-concat, as it is not needed anymore
* Use the minified version provided by the package manager when available (requirejs does not have one)

Also, I think it would be great to make a zip of the built dist folder, and provide it on the release page of the repository, so people which just want to use the decoder doesn't have to build it.

Best regards,
LRGN