### PR TITLE
auto detect seperator

### DIFF
--- a/src/scripts/app/FixParser.js
+++ b/src/scripts/app/FixParser.js
@@ -18,15 +18,31 @@ define(
             return parseFloat(beginStr.substr("FIX.".length));
         };
 
+        var splitFields = function(str) {
+            var result = str.match(/[^0-9a-zA-Z:\s]*8=FIX(?:[^=]{0,20}?)\D9=\d+(?<delim>.*?\D)35=/);
+            if (result !== null) {
+                return str.split(result.groups.delim);
+            } else
+            {
+                return str.split(/\||;|\x001|\[SOH\]|<SOH>|\^A/);
+            }
+        };
+
         FixParser.prototype.parse = function(str)
         {
             // Create a sequence of fields
-            var regex = /([0-9]+)=([^|;\001]*)/g,
+            var regex = /([0-9]+)=(.*)/,
                 fields = [], result;
 
             var fixVersion = 'unknown';
 
-            while (result = regex.exec(str)) {
+            var splits = splitFields(str);
+            for (var i=0; i<splits.length; ++i) {
+                // cut the fields by separators before extracting field id and value
+                result = splits[i].match(regex);
+                if (!result)
+                    continue;
+
                 var fieldId = parseInt(result[1]),
                     value = result[2],
                     field = data.fieldById[fieldId],


### PR DESCRIPTION
Because the first 3 tags in FIX message is 8/9/35, we can assume the same seperator is used in whole message, so we can detect it from these 3 tags.
Because the value of `9=` is always numbers, so we can use the string from the first non-number charater after `9=` to `35=` as seperator.